### PR TITLE
fix: couldn't detect when json value is numeric

### DIFF
--- a/sdk_test.go
+++ b/sdk_test.go
@@ -138,6 +138,43 @@ func TestDeidentifyJSONByResult(t *testing.T) {
 	}
 }
 
+func TestEngine_DetectJSON(t *testing.T) {
+	jsonTestCases := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  `{"phone":13312341234}`,
+			out: `{"phone":"13*******34"}`,
+		},
+		{
+			in:  `{"uid":1234567890}`,
+			out: `{"uid":"1*********"}`,
+		},
+	}
+	eng, err := NewEngine("replace.your.psm")
+	if err != nil {
+		t.Error(err)
+	}
+	err = eng.ApplyConfigDefault()
+	if err != nil {
+		t.Error(err)
+	}
+	for _, tc := range jsonTestCases {
+		detectRes, err := eng.DetectJSON(tc.in)
+		if err != nil {
+			t.Error(err)
+		}
+		out, err := eng.DeidentifyJSONByResult(tc.in, detectRes)
+		if err != nil {
+			t.Error(err)
+		}
+		if out != tc.out {
+			t.Errorf("incorrect output, expect: %s, actual: %s", tc.out, out)
+		}
+	}
+}
+
 // private func
 
 func setup() {

--- a/sdkinternal.go
+++ b/sdkinternal.go
@@ -4,13 +4,14 @@ package dlp
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+
 	"github.com/bytedance/godlp/detector"
 	"github.com/bytedance/godlp/errlist"
 	"github.com/bytedance/godlp/log"
 	"github.com/bytedance/godlp/mask"
-	"os"
-	"runtime/debug"
-	"strings"
 )
 
 type HttpResponseBase struct {
@@ -21,7 +22,7 @@ type HttpResponseBase struct {
 type DescribeRulesResponse struct {
 	HttpResponseBase
 	Rule []byte `json:"rule,omitempty"`
-	Crc  uint32 `json:"crc,omitempty"` //rule 的crc
+	Crc  uint32 `json:"crc,omitempty"` // rule 的crc
 }
 
 // private func
@@ -104,10 +105,10 @@ func (I *Engine) isDebugMode() bool {
 // in release mode, log level is ERROR and log message will be printed into stderr
 func (I *Engine) initLogger() error {
 	if I.isDebugMode() {
-		//log.SetLevel(0)
+		// log.SetLevel(0)
 		log.Debugf("DLP@%s run in debug mode", I.Version)
 	} else { // release mode
-		//log.SetLevel(log.LevelError)
+		// log.SetLevel(log.LevelError)
 	}
 	return nil
 }
@@ -186,6 +187,28 @@ func (I *Engine) dfsJSON(path string, ptr *interface{}, kvMap map[string]string,
 					return val
 				}
 			}
+		}
+	case float64:
+		// float64 don't need to mask
+		if val, ok := (*ptr).(float64); ok {
+			if isDeidentify {
+				if mask, ok := kvMap[path]; ok {
+					return mask
+				} else {
+					return val
+				}
+			}
+			kvMap[path] = fmt.Sprintf("%0.f", val)
+			return val
+		}
+	case bool:
+		// bool don't need to mask
+		if val, ok := (*ptr).(bool); ok {
+			kvMap[path] = fmt.Sprint(val)
+		}
+	case nil:
+		if path != "" {
+			kvMap[path] = fmt.Sprint(nil)
 		}
 	}
 	return *ptr


### PR DESCRIPTION
如果 json value 中敏感数据是数字型，之前是无法被探测出的。

Before
``` Go
jsonStr := `{"phone":13312341234}`
eng, err := NewEngine("replace.your.psm")
if err != nil {
	panic(err)
}
eng.ApplyConfigDefault()
result, _ := eng.DetectJSON(jsonStr)
if result == nil {
	fmt.Println("no sensitive info found")
} else {
	eng.ShowResults(result)
}
>>> output
no sensitive info found
```
Now
``` Go
jsonStr := `{"phone":13312341234}`
eng, err := NewEngine("replace.your.psm")
if err != nil {
	panic(err)
}
eng.ApplyConfigDefault()
result, _ := eng.DetectJSON(jsonStr)
if result == nil {
	fmt.Println("no sensitive info found")
} else {
	eng.ShowResults(result)
}
>>> output
Total Results: 1
Result[0]: {RuleID:35 Text:13312341234 MaskText:13*******34 ResultType:KV Key:/phone ByteStart:0 ByteEnd:11 InfoType:PHONE EnName:telephone_number CnName:电话号码 GroupName: Level:L4 ExtInfo:map[CnGroup:用户数据 EnGroup:user_data]}
```